### PR TITLE
Update authenticator to allow a username override using a claim

### DIFF
--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/duo/DuoAuthenticatorConstants.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/duo/DuoAuthenticatorConstants.java
@@ -41,6 +41,7 @@ public abstract class DuoAuthenticatorConstants {
     public static final String DUO_PHONES = "phones";
     public static final String DUO_PAGE = "duoauthenticationendpoint/duoAuth.jsp";
     public static final String ENABLE_MOBILE_VERIFICATION = "EnableMobileVerification";
+    public static final String OVERRIDE_USERNAME_CLAIM = "OverrideUsernameClaim";
     public static final String INTEGRATION_SECRET_KEY = "integrationSecretKey";
     public static final String SESSION_DATA_KEY = "sessionDataKey";
     public static final String HTTP_GET = "GET";


### PR DESCRIPTION
This adds a new constant & looks for its authenticator setting existence & value.  Overrides the username sent to Duo if used.

Fixes #10.