### PR TITLE
Add support for federated Identity Providers

### DIFF
--- a/component/authenticator/pom.xml
+++ b/component/authenticator/pom.xml
@@ -77,6 +77,21 @@
             <version>1.10</version>
         </dependency>
         <dependency>
+            <groupId>org.wso2.carbon.extension.identity.authenticator.utils</groupId>
+            <artifactId>org.wso2.carbon.extension.identity.helper</artifactId>
+            <version>${identity.extension.utils}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.wso2.carbon.identity</groupId>
+                    <artifactId>org.wso2.carbon.identity.application.authenticator.oidc</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.wso2.carbon.identity</groupId>
+                    <artifactId>org.wso2.carbon.identity.application.authentication.framework</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
             <groupId>org.jacoco</groupId>
             <artifactId>org.jacoco.agent</artifactId>
             <classifier>runtime</classifier>
@@ -174,6 +189,8 @@
                             org.wso2.carbon.identity.application.authentication.framework.*,
                             javax.servlet,
                             javax.servlet.http,
+                            org.wso2.carbon.extension.identity.helper.*;
+                            version="${identity.extension.utils.import.version.range}",
                             *;resolution:=optional
                         </Import-Package>
                         <Export-Package>

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/duo/DuoAuthenticator.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/duo/DuoAuthenticator.java
@@ -114,28 +114,6 @@ public class DuoAuthenticator extends AbstractApplicationAuthenticator implement
     }
 
     /**
-     * Get local authenticated user.
-     *
-     * @return username
-     */
-    private String getLocalAuthenticatedUser(AuthenticationContext context) {
-        //Getting the last authenticated local user
-        String username = null;
-        for (int i = context.getSequenceConfig().getStepMap().size() - 1; i > 0; i--) {
-            if (context.getSequenceConfig().getStepMap().get(i).getAuthenticatedUser() != null &&
-                    context.getSequenceConfig().getStepMap().get(i).getAuthenticatedAutenticator()
-                            .getApplicationAuthenticator() instanceof LocalApplicationAuthenticator) {
-                username = String.valueOf(context.getSequenceConfig().getStepMap().get(i).getAuthenticatedUser());
-                if (log.isDebugEnabled()) {
-                    log.debug("username :" + username);
-                }
-                break;
-            }
-        }
-        return username;
-    }
-
-    /**
      * Get DUO user's information.
      *
      * @param context  the authentication context

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/duo/DuoAuthenticatorConstants.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/duo/DuoAuthenticatorConstants.java
@@ -55,6 +55,8 @@ public abstract class DuoAuthenticatorConstants {
     public static final String USER_INFO = "userInfo";
     public static final String USER_STORE_DOMAIN = "UserStoreDomain";
     public static final String TENANT_DOMAIN = "TenantDomain";
+    public static final String USE_FEDERATED_MOBILE_CLAIM = "useFederatedMobileClaim";
+    public static final String FEDERATED_MOBILE_ATTRIBUTE_KEY = "federatedMobileNumberAttributeKey";
 
     public static class RequestParams {
         public static final String DUO = "duo";

--- a/component/authenticator/src/test/java/org/wso2/carbon/extension/identity/authenticator/duo/test/DuoAuthenticatorTest.java
+++ b/component/authenticator/src/test/java/org/wso2/carbon/extension/identity/authenticator/duo/test/DuoAuthenticatorTest.java
@@ -169,21 +169,6 @@ public class DuoAuthenticatorTest {
                 "abc");
     }
 
-    @Test(description = "Test case for getLocalAuthenticatedUser() method.")
-    public void testGetLocalAuthenticatedUser() throws Exception {
-
-        when(context.getSequenceConfig()).thenReturn(sequenceConfig);
-        when(sequenceConfig.getStepMap()).thenReturn(mockedMap);
-        when(mockedMap.size()).thenReturn(2);
-        when(mockedMap.get(anyObject())).thenReturn(stepConfig);
-        AuthenticatedUser user = AuthenticatedUser.createLocalAuthenticatedUserFromSubjectIdentifier("admin");
-        when(stepConfig.getAuthenticatedAutenticator()).thenReturn(authenticatorConfig);
-        when(authenticatorConfig.getApplicationAuthenticator()).thenReturn(localApplicationAuthenticator);
-        when(stepConfig.getAuthenticatedUser()).thenReturn(user);
-        Assert.assertEquals(Whitebox.invokeMethod(duoAuthenticator, "getLocalAuthenticatedUser", context),
-                "admin@carbon.super");
-    }
-
     @Test(description = "Test case for getMobileClaimValue() method.")
     public void testGetMobileClaimValue() throws Exception {
 

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,8 @@
  ~ specific language governing permissions and limitations
  ~ under the License.
 	 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.wso2</groupId>
@@ -134,6 +135,12 @@
             <groupId>org.wso2.carbon.identity</groupId>
             <artifactId>org.wso2.carbon.identity.application.authenticator.oidc</artifactId>
             <version>${carbon.identity.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.extension.identity.authenticator.utils</groupId>
+            <artifactId>org.wso2.carbon.extension.identity.helper</artifactId>
+            <version>${identity.extension.utils}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -399,5 +406,7 @@
         <testng.version>6.9.10</testng.version>
         <jacoco.version>0.7.9</jacoco.version>
         <maven.surefire.plugin.version>2.18.1</maven.surefire.plugin.version>
+        <identity.extension.utils>1.0.8</identity.extension.utils>
+        <identity.extension.utils.import.version.range>[1.0.8,2.0.0)</identity.extension.utils.import.version.range>
     </properties>
 </project>


### PR DESCRIPTION
Resolves https://github.com/wso2/product-is/issues/6455

### Instructions 

Please note that the following properties should be configured in the `<IS_HOME>/repository/conf/identity/application-authentication.xml`.

```
<AuthenticatorConfigs>
     ...
     <AuthenticatorConfig name="DuoAuthenticator" enabled="true">
          ...
          <Parameter name="usecase">association</Parameter>
          <Parameter name="useFederatedMobileClaim">true</Parameter>
          <Parameter name="federatedMobileNumberAttributeKey">http://wso2.org/claims/mobile</Parameter>
          <Parameter name="secondaryUserstore">primary</Parameter>
          ...
     </AuthenticatorConfig>
     ...
</AuthenticatorConfigs>
```

- `useFederatedMobileClaim` - Specifies whether the mobile number claim should be taken from the claims provided by the Identity Provider.
- `federatedMobileNumberAttributeKey` - Specifies the value of the mobile claim provided by the Identity Provider. This property must be configured if the `useFederatedMobileClaim` is `true`.
- `usecase` - This field can take one of the following values: local, association, userAttribute, subjectUri. If you do not specify any usecase, the default value is local.
- `secondaryUserstore` - The user store configuration is maintained per tenant as comma separated values. For example, <Parameter name="secondaryUserstore">jdbc, abc, and xyz</Parameter>.

    The usecase value can be `local`, `association`,
    `             userAttribute            ` or
    `             subjectUri            ` .

    <table>
    <tbody>
    <tr class="odd">
    <td><code>                 local                </code></td>
    <td><p>This is based on the federated username. This is the default value. You must set the federated username in the localuserstore. Basically, the federated username must be the same as the local username.</p></td>
    </tr>
    <tr class="even">
    <td><code>                 association                </code></td>
    <td><p>The federated username must be associated with the local account in advance in the Dashboard. So the local username is retrieved from the association. To associate the user, log into the <a href="../../learn/using-the-end-user-dashboard">end user dashboard</a> and go to <strong>Associated Account</strong> by clicking <strong>View details</strong> .</p></td>
    </tr>
    <tr class="odd">
    <td><code>                 userAttribute                </code></td>
    <td><div class="content-wrapper">
    <p>The name of the  federatedauthenticator's user attribute. That is,the local user namewhich is contained in a federated user's attribute. When using this, add the following parameter under the <code>                   &lt;AuthenticatorConfig name="Duo" enabled="true"&gt;                  </code> section in the <code>                   &lt;IS_HOME&gt;/repository/conf/identity/application-authentication.xml                  </code> file and put the value (e.g., email, screen_name, id, etc.).</p>
    <div class="code panel pdl" style="border-width: 1px;">
    <div class="codeContent panelContent pdl">
    <div class="sourceCode" id="cb1" data-syntaxhighlighter-params="brush: xml; gutter: false; theme: Confluence" data-theme="Confluence" style="brush: xml; gutter: false; theme: Confluence"><pre class="sourceCode xml"><code class="sourceCode xml"><a class="sourceLine" id="cb1-1" title="1"><span class="kw">&lt;Parameter</span><span class="ot"> name=</span><span class="st">&quot;userAttribute&quot;</span><span class="kw">&gt;</span>email<span class="kw">&lt;/Parameter&gt;</span></a></code></pre></div>
    </div>
    </div>
    <p>If you use, OpenID Connect supported authenticators such as LinkedIn, Foursquare, etc., or in the case of multiple social login options as the first step and Duo as second step, you need to add similar configuration for the specific authenticator in the <code>                   &lt;IS_HOME&gt;/repository/conf/identity/application-authentication.xml                  </code> file under the &lt; <code>                   AuthenticatorConfigs                  </code> &gt; section as follows (the following shows the configuration forFoursquare,LinkedIn and Facebook authenticator respectively).</p>
    <p>Inside the <code>                   AuthenticatorConfig                  </code> (i.e., Foursquare), add the specific <code>                   userAttribute                  </code> with a prefix of the (current step) authenticator name (i.e., Duo-userAttribute).</p>
    <div class="code panel pdl" style="border-width: 1px;">
    <div class="codeContent panelContent pdl">
    <div class="sourceCode" id="cb2" data-syntaxhighlighter-params="brush: xml; gutter: false; theme: Confluence" data-theme="Confluence" style="brush: xml; gutter: false; theme: Confluence"><pre class="sourceCode xml"><code class="sourceCode xml"><a class="sourceLine" id="cb2-1" title="1"><span class="kw">&lt;AuthenticatorConfig</span><span class="ot"> name=</span><span class="st">&quot;Foursquare&quot;</span><span class="ot"> enabled=</span><span class="st">&quot;true&quot;</span><span class="kw">&gt;</span></a>
    <a class="sourceLine" id="cb2-2" title="2">       <span class="kw">&lt;Parameter</span><span class="ot"> name=</span><span class="st">&quot;SMSOTP-userAttribute&quot;</span><span class="kw">&gt;</span>http://wso2.org/foursquare/claims/email<span class="kw">&lt;/Parameter&gt;</span></a>
    <a class="sourceLine" id="cb2-3" title="3"><span class="kw">&lt;/AuthenticatorConfig&gt;</span></a></code></pre></div>
    </div>
    </div>
    <div class="code panel pdl" style="border-width: 1px;">
    <div class="codeContent panelContent pdl">
    <div class="sourceCode" id="cb3" data-syntaxhighlighter-params="brush: xml; gutter: false; theme: Confluence" data-theme="Confluence" style="brush: xml; gutter: false; theme: Confluence"><pre class="sourceCode xml"><code class="sourceCode xml"><a class="sourceLine" id="cb3-1" title="1"><span class="kw">&lt;AuthenticatorConfig</span><span class="ot"> name=</span><span class="st">&quot;LinkedIn&quot;</span><span class="ot"> enabled=</span><span class="st">&quot;true&quot;</span><span class="kw">&gt;</span></a>
    <a class="sourceLine" id="cb3-2" title="2">   <span class="kw">&lt;Parameter</span><span class="ot"> name=</span><span class="st">&quot;SMSOTP-userAttribute&quot;</span><span class="kw">&gt;</span>http://wso2.org/linkedin/claims/emailAddress<span class="kw">&lt;/Parameter&gt;</span></a>
    <a class="sourceLine" id="cb3-3" title="3"><span class="kw">&lt;/AuthenticatorConfig&gt;</span></a></code></pre></div>
    </div>
    </div>
    <div class="code panel pdl" style="border-width: 1px;">
    <div class="codeContent panelContent pdl">
    <div class="sourceCode" id="cb4" data-syntaxhighlighter-params="brush: xml; gutter: false; theme: Confluence" data-theme="Confluence" style="brush: xml; gutter: false; theme: Confluence"><pre class="sourceCode xml"><code class="sourceCode xml"><a class="sourceLine" id="cb4-1" title="1"><span class="kw">&lt;AuthenticatorConfig</span><span class="ot"> name=</span><span class="st">&quot;FacebookAuthenticator&quot;</span><span class="ot"> enabled=</span><span class="st">&quot;true&quot;</span><span class="kw">&gt;</span></a>
    <a class="sourceLine" id="cb4-2" title="2">    <span class="kw">&lt;Parameter</span><span class="ot"> name=</span><span class="st">&quot;SMSOTP-userAttribute&quot;</span><span class="kw">&gt;</span>email<span class="kw">&lt;/Parameter&gt;</span></a>
    <a class="sourceLine" id="cb4-3" title="3"><span class="kw">&lt;/AuthenticatorConfig&gt;</span></a></code></pre></div>
    </div>
    </div>
    <p>Likewise, you can add the AuthenticatorConfig forAmazon,Google,Twitterand Instagram with relevant values.</p>
    </div></td>
    </tr>
    <tr class="even">
    <td><code>                 subjectUri                </code></td>
    <td><p>When configuring the federated authenticator, select the attribute in the subject identifier under the service provider section in UI, this is used as the username of the Duo authenticator.</p></td>
    </tr>
    </tbody>
    </table>