### PR TITLE
Remove Securevault Dependancy

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -170,17 +170,6 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>org.wso2.securevault</groupId>
-            <artifactId>org.wso2.securevault</artifactId>
-            <version>${org.wso2.securevault.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>commons-lang</groupId>
-                    <artifactId>commons-lang</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
             <groupId>org.wso2.orbit.org.owasp.encoder</groupId>
             <artifactId>encoder</artifactId>
             <version>${encoder.wso2.version}</version>
@@ -379,7 +368,6 @@
         <javax.servlet-api.version>3.0-alpha-1</javax.servlet-api.version>
         <commons-codec.version>1.4.0.wso2v1</commons-codec.version>
         <axiom.version>1.2.11-wso2v6</axiom.version>
-        <org.wso2.securevault.version>1.1.3</org.wso2.securevault.version>
         <commons-lang.wso2.version>2.6.0.wso2v1</commons-lang.wso2.version>
         <encoder.wso2.version>1.2.0.wso2v1</encoder.wso2.version>
         <mockito.version>1.10.19</mockito.version>


### PR DESCRIPTION
## Purpose
$subject in order to resolve the issue : https://github.com/wso2/product-is/issues/14747
The securevault jar in the `duoauthenticationendpoint` is older. Therefore,the encryption of secrets using ciphertool fails. 
Since we already have a new securevault jar in plugins, we are removing the older jar.

