### PR TITLE
Refactor pom.xml and code to support WSO2 IS 5.10

### DIFF
--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/duo/DuoAuthenticator.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/duo/DuoAuthenticator.java
@@ -554,7 +554,7 @@ public class DuoAuthenticator extends AbstractApplicationAuthenticator implement
                     toString(), requestState);
 
             if (!isValidResponse) {
-                throw new AuthenticationFailedException(DuoAuthenticatorConstants.DuoErrors.ERROR_VERIFY_USER,
+                throw new AuthenticationFailedException(DuoAuthenticatorConstants.DuoErrors.ERROR_VERIFY_USER + 
                         "Authentication failed!. Duo response state does not match with the context state");
             }
             AuthenticatedUser authenticatedUser = (AuthenticatedUser) context

--- a/pom.xml
+++ b/pom.xml
@@ -477,7 +477,7 @@
         </snapshotRepository>
     </distributionManagement>
     <properties>
-        <carbon.identity.version>5.25.166</carbon.identity.version>
+        <carbon.identity.version>5.17.117</carbon.identity.version>
         <carbon.identity.association.version>5.4.0</carbon.identity.association.version>
         <carbon.identity.outbound.auth.openid.version>5.5.0</carbon.identity.outbound.auth.openid.version>
         <carbon.identity.outbound.auth.oidc.version>5.5.0</carbon.identity.outbound.auth.oidc.version>


### PR DESCRIPTION
## Purpose
Adds support for WSO2 IS 5.10.0

## Goals
WSO2 IS 5.10 instance is able to deploy and use Duo Web v4 - Universal Prompt as a federated authenticator

## Approach
Follow steps in config.md and authenticator/setup.md to deploy artifact.

## User stories
As an administrator, I want to use Duo - Universal Prompt to avoid the end-of-life date for Duo Web SDK v2

## Release note
Enables Duo Web v4 - Universal Prompt for WSO2 IS 5.10 

## Documentation
N/A

## Training
N/A

## Certification
M/A
## Marketing
> Link to drafts of marketing content that will describe and promote this feature, including product page changes, technical articles, blog posts, videos, etc., if applicable

## Automation tests
 - Unit tests 
15/15 passed unit tests
 - Integration tests
N/A

## Security checks
N/A

## Samples
N/A

## Related PRs
[> List any other related PRs](https://github.com/wso2-extensions/identity-outbound-auth-duo/pull/54)

## Migrations (if applicable)
N/A

## Test environment
OS X / JDK 1.8
Ubuntu / JDK 11
 
## Learning
N/A