### PR TITLE
Fix unit test

### DIFF
--- a/component/authenticator/src/test/java/org/wso2/carbon/extension/identity/authenticator/duo/test/DuoAuthenticatorTest.java
+++ b/component/authenticator/src/test/java/org/wso2/carbon/extension/identity/authenticator/duo/test/DuoAuthenticatorTest.java
@@ -187,6 +187,7 @@ public class DuoAuthenticatorTest {
         when(userRealm.getUserStoreManager()).thenReturn(userStoreManager);
         AuthenticatedUser authenticatedUser = new AuthenticatedUser();
         authenticatedUser.setUserName("admin");
+        authenticatedUser.setAuthenticatedSubjectIdentifier("admin@carbon.super");
         when((AuthenticatedUser) context.getProperty("authenticatedUser")).thenReturn(authenticatedUser);
         when(userRealm.getUserStoreManager()
                 .getUserClaimValue(MultitenantUtils.getTenantAwareUsername("admin"),


### PR DESCRIPTION
## Purpose

Currently, testGetMobileClaimValue unit test fails with the following error. This PR fixes the test failure.
```
<<< FAILURE!
[INFO] java.lang.NullPointerException: null
[INFO] 	at org.wso2.carbon.utils.multitenancy.MultitenantUtils.getTenantAwareUsername(MultitenantUtils.java:51)
[INFO] 	at org.wso2.carbon.identity.authenticator.duo.DuoAuthenticator.getMobileClaimValue(DuoAuthenticator.java:360)
[INFO] 	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
[INFO] 	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
[INFO] 	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
[INFO] 	at java.lang.reflect.Method.invoke(Method.java:498)
[INFO] 	at org.powermock.reflect.internal.WhiteboxImpl.performMethodInvocation(WhiteboxImpl.java:1899)
[INFO] 	at org.powermock.reflect.internal.WhiteboxImpl.doInvokeMethod(WhiteboxImpl.java:801)
[INFO] 	at org.powermock.reflect.internal.WhiteboxImpl.invokeMethod(WhiteboxImpl.java:666)
[INFO] 	at org.powermock.reflect.Whitebox.invokeMethod(Whitebox.java:401)
[INFO] 	at org.wso2.carbon.extension.identity.authenticator.duo.test.DuoAuthenticatorTest.testGetMobileClaimValue(DuoAuthenticatorTest.java:194)
[INFO] 
[INFO] 
[INFO] Results :
[INFO] 
[INFO] Failed tests: 
[INFO]   DuoAuthenticatorTest.testGetMobileClaimValue:194 » NullPointer
```
### Related PRs
- https://github.com/wso2-extensions/identity-outbound-auth-duo/pull/59