### PR TITLE
Add missing OSGi import for org.json to support IS 7.0.0

### DIFF
--- a/component/authenticator/pom.xml
+++ b/component/authenticator/pom.xml
@@ -207,6 +207,7 @@
                             org.wso2.carbon.identity.core*;version="${carbon.identity.package.import.version.range}",
                             org.wso2.carbon.utils*;version="${carbon.kernel.package.import.version.range}",
                             org.osgi.service.component;version="${osgi.service.component.imp.pkg.version.range}",
+                            org.json;version="${org.json.package.import.version}",
                             *;resolution:=optional
                         </Import-Package>
                         <Embed-Dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -543,5 +543,6 @@
         <apache.amber.version>0.22.1358727.wso2v4</apache.amber.version>
         <json.version>20231013</json.version>
         <commons-logging.osgi.version.range>[1.2,2.0)</commons-logging.osgi.version.range>
+        <org.json.package.import.version>3.0.0.wso2v5</org.json.package.import.version>
     </properties>
 </project>


### PR DESCRIPTION
### Purpose

Fix the issue where the Duo Authenticator does not activate in **WSO2 Identity Server 7.0.0** due to a missing `org.json` OSGi package import.

### Goals

- Ensure the Duo Authenticator bundle activates properly in **IS 7.0.0**.
- Maintain consistency in version management by introducing a dedicated Maven property for the `org.json` package version.

### Approach

- Added a new Maven property `org.json.package.import.version` in the `pom.xml` with the value `3.0.0.wso2v5`.
- Updated the OSGi `Import-Package` section in the `maven-bundle-plugin` configuration to explicitly import the `org.json` package using the above property.
- Rebuilt and verified the Duo Authenticator functionality on a local deployment of **IS 7.0.0**, confirming successful bundle activation and expected behavior in the authentication flow.

### Releaed PRs
  - https://github.com/wso2-extensions/identity-outbound-auth-duo/pull/74

## Related Issues
product-is issue: https://github.com/wso2/product-is/issues/24701