### PR TITLE
Update version to v4.0.11 and bump Duo SDK dependencies

### DIFF
--- a/.connector-store/meta.json
+++ b/.connector-store/meta.json
@@ -8,7 +8,7 @@
     "labels": ["Federated Authenticator", "Multi-factor Authentication"],
     "releases": [
         {
-            "tagName": "v4.0.10",
+            "tagName": "v4.0.11",
             "products": [
                 "IS 7.0.0",
                 "IS 7.1.0"

--- a/pom.xml
+++ b/pom.xml
@@ -528,8 +528,8 @@
         <maven.checkstyleplugin.version>3.1.0</maven.checkstyleplugin.version>
         <oltu.auth2.client.version>0.31</oltu.auth2.client.version>
         <oltu.auth2.common.version>1.0.1</oltu.auth2.common.version>
-        <duo.universal.sdk.version>1.1.3</duo.universal.sdk.version>
-        <duo.client.version>0.6.0</duo.client.version>
+        <duo.universal.sdk.version>1.3.1</duo.universal.sdk.version>
+        <duo.client.version>0.7.1</duo.client.version>
         <codehaus.mojo.version>1.10</codehaus.mojo.version>
         <squareup.okio.version>1.17.6</squareup.okio.version>
         <squareup.okhttp.okhttp.version>2.7.5</squareup.okhttp.okhttp.version>


### PR DESCRIPTION
## Purpose
The purpose of this pull request is to update the Duo Security connector dependencies to align with Cisco Duo’s latest certificate authority (CA) bundle requirements.
Cisco Duo’s existing CA bundle will expire on April 15, 2026, with a soft cutoff on February 2, 2026. Since the Duo Universal SDK and Duo Client rely on CA certificate pinning, outdated dependencies will cause TLS handshake failures once the old bundle expires.

This update ensures continued compatibility and secure communication with Duo’s API.

## Related Issue
- [Public] https://github.com/wso2/product-is/issues/25596

## Implementation
This pull request updates the Duo SDK dependencies to newer versions in the `pom.xml` file. These updates will ensure compatibility with the latest features and bug fixes provided by Duo.

Dependency version updates:

* Upgraded `duo.universal.sdk.version` from `1.1.3` to `1.3.1` to use the latest Duo Universal SDK.
* Upgraded `duo.client.version` from `0.6.0` to `0.7.1` for the latest Duo client library improvements.