### PR TITLE
Add a null check to factor parameter in the Duo token

### DIFF
--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/duo/DuoAuthenticator.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/duo/DuoAuthenticator.java
@@ -716,7 +716,7 @@ public class DuoAuthenticator extends AbstractApplicationAuthenticator implement
                                         null, false),
                                 authContext.get(DuoAuthenticatorConstants.FACTOR).toString());
                     } else {
-                        log.debug("Auth context or factor value is null — skipping AMR attribute addition.");
+                        log.debug("Skipping addition of AMR attribute due to factor value being null.");
                     }
                 } else if (entry.getValue() instanceof String) {
                     userAttributes.put(

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/duo/DuoAuthenticator.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/duo/DuoAuthenticator.java
@@ -710,10 +710,14 @@ public class DuoAuthenticator extends AbstractApplicationAuthenticator implement
                 if (entry.getKey().equals(DuoAuthenticatorConstants.AUTH_CONTEXT) && entry.getValue() instanceof Map) {
                     Map<String, Object> authContext = (Map<String, Object>) entry.getValue();
                     // Add amr value
-                    userAttributes.put(
-                            ClaimMapping.build(DuoAuthenticatorConstants.AMR, DuoAuthenticatorConstants.AMR,
-                                    null, false),
-                            authContext.get(DuoAuthenticatorConstants.FACTOR).toString());
+                    if (authContext.get(DuoAuthenticatorConstants.FACTOR) != null) {
+                        userAttributes.put(
+                                ClaimMapping.build(DuoAuthenticatorConstants.AMR, DuoAuthenticatorConstants.AMR,
+                                        null, false),
+                                authContext.get(DuoAuthenticatorConstants.FACTOR).toString());
+                    } else {
+                        log.debug("Auth context or factor value is null — skipping AMR attribute addition.");
+                    }
                 } else if (entry.getValue() instanceof String) {
                     userAttributes.put(
                             ClaimMapping.build(entry.getKey(), entry.getKey(), null, false),


### PR DESCRIPTION
### Purpose
In the Traditional Prompt flow, Duo’s /auth API always returned a factor field, allowing the connector to rely on it. With the Universal Prompt, Duo issues standard OIDC tokens that may not include this claim. This fix makes the connector handle the missing factor field gracefully by treating it as optional and falling back to the default AMR behavior.

### Implementation
Added a check for the presence of the factor value before using it.

### Related Issue
- https://github.com/wso2/product-is/issues/25901