### PR TITLE
Update org.json package import version range in pom.xml

### DIFF
--- a/component/authenticator/pom.xml
+++ b/component/authenticator/pom.xml
@@ -207,7 +207,7 @@
                             org.wso2.carbon.identity.core*;version="${carbon.identity.package.import.version.range}",
                             org.wso2.carbon.utils*;version="${carbon.kernel.package.import.version.range}",
                             org.osgi.service.component;version="${osgi.service.component.imp.pkg.version.range}",
-                            org.json;version="${org.json.package.import.version}",
+                            org.json;version="${org.json.package.import.version.range}",
                             *;resolution:=optional
                         </Import-Package>
                         <Embed-Dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -543,6 +543,6 @@
         <apache.amber.version>0.22.1358727.wso2v4</apache.amber.version>
         <json.version>20231013</json.version>
         <commons-logging.osgi.version.range>[1.2,2.0)</commons-logging.osgi.version.range>
-        <org.json.package.import.version>[3.0.0.wso2v1, 4.0.0)</org.json.package.import.version>
+        <org.json.package.import.version.range>[3.0.0.wso2v1, 4.0.0)</org.json.package.import.version.range>
     </properties>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -543,6 +543,6 @@
         <apache.amber.version>0.22.1358727.wso2v4</apache.amber.version>
         <json.version>20231013</json.version>
         <commons-logging.osgi.version.range>[1.2,2.0)</commons-logging.osgi.version.range>
-        <org.json.package.import.version>3.0.0.wso2v5</org.json.package.import.version>
+        <org.json.package.import.version>[3.0.0.wso2v1, 4.0.0)</org.json.package.import.version>
     </properties>
 </project>


### PR DESCRIPTION
## Related Issue
- https://github.com/wso2/product-is/issues/26616

## Purpose
This pull request updates the version range for the `org.json` package import in the `pom.xml` file to allow for greater compatibility with future versions.

Dependency version update:

* Expanded the `org.json.package.import.version` property from a fixed version (`3.0.0.wso2v5`) to a version range (`[3.0.0.wso2v1, 4.0.0)`) in `pom.xml`, enabling compatibility with any `3.x` version up to but not including `4.0.0`.